### PR TITLE
fix: Parse year to integer in expense creation

### DIFF
--- a/src/components/admin/FinancialFormModal.tsx
+++ b/src/components/admin/FinancialFormModal.tsx
@@ -130,7 +130,8 @@ const FinancialFormModal: React.FC<FinancialFormModalProps> = ({
           case 'expense':
             await financialService.createExpense({
               ...formData,
-              amount: parseFloat(formData.amount)
+              amount: parseFloat(formData.amount),
+              year: parseInt(formData.year, 10)
             } as ExpenseCreate);
             toast.success('Expense created successfully');
             break;


### PR DESCRIPTION
This pull request updates the `FinancialFormModal` component in the `src/components/admin/FinancialFormModal.tsx` file to include a new `year` field when creating an expense. This change ensures that the `year` is properly parsed and sent to the `financialService`.

Key change:

* [`src/components/admin/FinancialFormModal.tsx`](diffhunk://#diff-6337fc6443aad6b36d2b4bc461eecf3561cbfdbd0b0d92fdf827b3fb0e07de70L133-R134): Added a `year` field to the `createExpense` method, parsing it as an integer using `parseInt`. This ensures the `year` is included in the payload for expense creation.